### PR TITLE
Fix encoding bug while reading rules.json.

### DIFF
--- a/src/telegram_sticker_utils/core/const.py
+++ b/src/telegram_sticker_utils/core/const.py
@@ -9,7 +9,7 @@ USERNAME = "telegram"
 
 # 读取规则，本文件目录下的rules.json
 rule_file = Path(__file__).parent / "rules.json"
-EMOJI_RULES = json.loads(rule_file.read_text())
+EMOJI_RULES = json.loads(rule_file.read_text(encoding='utf-8'))
 
 
 def add_emoji_rule(rule: str, emoji_char: str):


### PR DESCRIPTION
In a Chinese Windows environment, files are by default read using the GBK encoding, which causes issues. This commit fixes the problem.